### PR TITLE
Extend eval dataset and add runner

### DIFF
--- a/evals/grc_eval.jsonl
+++ b/evals/grc_eval.jsonl
@@ -26,3 +26,27 @@
   "input": "What does the README state about Documentation Standards?",
   "ideal": "All agent activities are predicated on documented expectations and generate discoverable information, as described in the Documentation Standards files."
 }
+{
+  "input": "According to the Glossary, how is an 'Audit' defined?",
+  "ideal": "A systematic review to ensure accuracy and compliance in financial and operational activities is essential in the GRC framework for maintaining integrity and transparency."
+}
+{
+  "input": "According to the Glossary, how is a 'Budget' defined?",
+  "ideal": "A financial plan outlining expected income and expenses is a cornerstone for resource allocation and financial management."
+}
+{
+  "input": "In 'Standards_Documentation.md', what is the first step of the Documentation Standards?",
+  "ideal": "Establish Context."
+}
+{
+  "input": "What does 'Standards_Documentation.md' instruct regarding fallacies?",
+  "ideal": "Warn of Fallacies in Prompts and Outputs."
+}
+{
+  "input": "Under the 'You Must Monitor' section of 'Standards_Operating.md', what action is required?",
+  "ideal": "Regularly monitor the outcomes of decisions and actions taken, tracking the effectiveness of plans and policies in real time."
+}
+{
+  "input": "According to 'Standards_Planning.md', what must an Operational Plan describe?",
+  "ideal": "The required Organizational Infrastructure, Business Process, and Implementation Schedule."
+}

--- a/evals/run_eval.py
+++ b/evals/run_eval.py
@@ -1,0 +1,40 @@
+import json
+from pathlib import Path
+
+
+def load_dataset(path: str):
+    """Load evaluation dataset from a jsonl file with multi-line JSON objects."""
+    data = []
+    buffer = ""
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            stripped = line.strip()
+            if not stripped:
+                continue
+            buffer += stripped
+            if stripped.endswith("}"):
+                data.append(json.loads(buffer))
+                buffer = ""
+    if buffer:
+        data.append(json.loads(buffer))
+    return data
+
+
+def dummy_model(prompt: str) -> str:
+    """Placeholder for model inference."""
+    return "(model output)"
+
+
+def evaluate(dataset_path: str):
+    dataset = load_dataset(dataset_path)
+    for example in dataset:
+        response = dummy_model(example["input"])
+        print("Prompt:", example["input"])
+        print("Model response:", response)
+        print("Ideal answer:", example["ideal"])
+        print()
+
+
+if __name__ == "__main__":
+    eval_file = Path(__file__).with_name("grc_eval.jsonl")
+    evaluate(str(eval_file))


### PR DESCRIPTION
## Summary
- add new questions to `grc_eval.jsonl` covering more standards and glossary terms
- provide `run_eval.py` example script showing how to consume dataset

## Testing
- `pytest -q` *(fails: command not found)*
- `python -m pytest -q` *(fails: No module named pytest)*
- `python evals/run_eval.py | head`